### PR TITLE
Product Catalog: Add Music and Genre class

### DIFF
--- a/classes/genre.rb
+++ b/classes/genre.rb
@@ -1,0 +1,16 @@
+require_relative './item'
+
+class Genre < Item
+  attr_accessor :id, :items
+    attr_reader :name
+
+    def initialize(name)
+        @name = name
+        @items = []
+        @id = Random.rand(1..100)
+    end
+     def add_item(item)
+        @items << item
+        item.genre = self
+    end
+end

--- a/classes/music_album.rb
+++ b/classes/music_album.rb
@@ -1,0 +1,15 @@
+require_relative './item'
+
+class MusicAlbum < Item
+    attr_accessor :on_spotify
+
+    def initialize(publish_date, archived, on_spotify)
+        super(publish_date, archived)
+        @on_spotify = on_spotify
+    end
+
+    def can_be_archived?
+       return true if super && @on_spotify
+         false
+     end
+end


### PR DESCRIPTION
In this pull request I implemented the following:

     - Created a Music Album class
     - Created a Genre class
- add_item method in the Genre class:
     - takes an instance of the Item class as an input
     - adds the input item to the collection of items
     - adds self as a property of the item object (by using the correct setter from the item object)
- can_be_archived?() in the MusicAlbum class:
      - overrides the method from the parent class
      - returns true if parent's method returns true AND if on_spotify equals true
      - otherwise, it returns false